### PR TITLE
Fix trade fee variable typo

### DIFF
--- a/programs/easy-amm/src/instructions/shared.rs
+++ b/programs/easy-amm/src/instructions/shared.rs
@@ -223,8 +223,8 @@ pub fn deposit_single_token_type(
 ) -> Option<u128> {
     // 获取在将“源代币数量的一半”兑换为另一种代币时产生的交易手续费
     let half_source_amount = std::cmp::max(1, source_amount.checked_div(2)?);
-    let tred_fee = calculation_fee(half_source_amount, trade_fee_amount)?;
-    let source_amount = source_amount.checked_sub(tred_fee)?;
+    let trade_fee = calculation_fee(half_source_amount, trade_fee_amount)?;
+    let source_amount = source_amount.checked_sub(trade_fee)?;
 
     let swap_source_amount = PreciseNumber::new(swap_token_amount)?;
     let source_amount = PreciseNumber::new(source_amount)?;


### PR DESCRIPTION
## Summary
- rename `tred_fee` to `trade_fee`
- compile workspace to ensure success

## Testing
- `cargo build --workspace`

------
https://chatgpt.com/codex/tasks/task_e_683ff19c146c832eaf2310866f710530