### PR TITLE
Fix withdraw_all balance check

### DIFF
--- a/programs/easy-amm/src/instructions/withdraw_all.rs
+++ b/programs/easy-amm/src/instructions/withdraw_all.rs
@@ -115,7 +115,7 @@ impl<'info> WithdrawAll<'info> {
     ) -> Result<()> {
         require_gt!(token_amount, Swap::MIN_TOKEN_AMOUNT, SwapError::WithdrawTooSmall);
         require!(
-            token_amount < self.user_mint_account.amount, 
+            token_amount <= self.user_mint_account.amount,
             SwapError::InsufficientPoolTokenBalance
         );
 


### PR DESCRIPTION
## Summary
- use `<=` when verifying pool token balance in withdraw_all

## Testing
- `cargo test --manifest-path programs/easy-amm/Cargo.toml -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_683ff199cb8c832eb7f7c82079056e3b