### PR TITLE
Fix function name

### DIFF
--- a/programs/easy-amm/src/instructions/deposit.rs
+++ b/programs/easy-amm/src/instructions/deposit.rs
@@ -3,7 +3,7 @@
 use anchor_lang::prelude::*;
 use anchor_spl::{associated_token::AssociatedToken, token_interface::{Mint, TokenAccount, TokenInterface}};
 
-use crate::{error::SwapError, events::DepositEvent, shared::{mint_tokens, pool_tokens_to_trading_toknes, to_u64, transfer_tokens}, state::Swap};
+use crate::{error::SwapError, events::DepositEvent, shared::{mint_tokens, pool_tokens_to_trading_tokens, to_u64, transfer_tokens}, state::Swap};
 
 
 #[derive(Accounts)]
@@ -102,7 +102,7 @@ impl<'info> Deposit<'info> {
             SwapError::DepositPoolTokenAmountTooSmall
         );
 
-        let (token_a_amount, token_b_amount) = pool_tokens_to_trading_toknes(
+        let (token_a_amount, token_b_amount) = pool_tokens_to_trading_tokens(
             true,
             u128::from(pool_token_amount), 
             u128::from(self.pool_mint.supply), 

--- a/programs/easy-amm/src/instructions/shared.rs
+++ b/programs/easy-amm/src/instructions/shared.rs
@@ -143,7 +143,7 @@ pub fn to_u64(val: u128) -> Result<u64> {
 
 /// 根据提供的池子代币数量、总交易代币数量和池子代币总供应量，计算可兑换的交易代币数量。
 /// 计算可兑换的交易代币数量。
-pub fn pool_tokens_to_trading_toknes(
+pub fn pool_tokens_to_trading_tokens(
     ceiling: bool,
     pool_tokens: u128,
     pool_token_supply: u128,

--- a/programs/easy-amm/src/instructions/withdraw_all.rs
+++ b/programs/easy-amm/src/instructions/withdraw_all.rs
@@ -8,7 +8,7 @@ use crate::{
     error::SwapError, events::WithdrawAllEvent, shared::{
         burn_tokens, 
         calculation_fee, 
-        pool_tokens_to_trading_toknes, 
+        pool_tokens_to_trading_tokens,
         to_u64, 
         transfer_tokens
     }, state::Swap
@@ -134,7 +134,7 @@ impl<'info> WithdrawAll<'info> {
             .checked_sub(withdraw_fee)
             .ok_or(SwapError::CalculationFailure)?;
 
-        let (token_a_amount, token_b_amount) = pool_tokens_to_trading_toknes(
+        let (token_a_amount, token_b_amount) = pool_tokens_to_trading_tokens(
             false,
             u128::from(token_amount), 
             u128::from(self.pool_mint.supply), 


### PR DESCRIPTION
## Summary
- rename `pool_tokens_to_trading_toknes` to `pool_tokens_to_trading_tokens`
- update imports and usage in deposit and withdraw modules

## Testing
- `cargo test`
- `anchor test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff1979958832e878642780bb3f845