### PR TITLE
Fix withdraw_all lp check

### DIFF
--- a/programs/easy-amm/src/instructions/withdraw_all.rs
+++ b/programs/easy-amm/src/instructions/withdraw_all.rs
@@ -115,7 +115,7 @@ impl<'info> WithdrawAll<'info> {
     ) -> Result<()> {
         require_gt!(token_amount, Swap::MIN_TOKEN_AMOUNT, SwapError::WithdrawTooSmall);
         require!(
-            token_amount < self.user_mint_account.amount, 
+            token_amount <= self.user_mint_account.amount,
             SwapError::InsufficientPoolTokenBalance
         );
 


### PR DESCRIPTION
## Summary
- allow withdrawing entire LP balance by using `<=` when checking user LP amount

## Testing
- `cargo test --manifest-path programs/easy-amm/Cargo.toml`
- `npx ts-mocha -p ./tsconfig.json tests/**/*.ts` *(fails: ts-mocha not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683feeab4170832ebfee2b8007bdecd9